### PR TITLE
Ignore helptags generated tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 textile*.zip
 *.swp
+doc/tags


### PR DESCRIPTION
Important to have this when using textile.vim via pathogen as a git submodule

Thanks
